### PR TITLE
Corrected hashtable spelling in Example 6

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Content.md
@@ -99,7 +99,7 @@ Get-Content .\Copy-Scripts.ps1 -Stream Zone.Identifier
 ZoneId=3
 ```
 
-### Example 6: Getting a hashtable out of file contents as a hastable
+### Example 6: Getting a hashtable out of file contents as a hashtable
 
 The commands in this example get the contents of a module manifest file (.psd1) as a hash table.
 The manifest file contains a hash table, but if you get the contents without the `-Raw` dynamic parameter, it is returned as an array of newline-delimited strings.


### PR DESCRIPTION
Incorrect spelling of hashtable

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
